### PR TITLE
Bump dependencies to support GHC 8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dist/
+/dist-newstyle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
     - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
     - env: CABALVER=1.24 GHCVER=8.0.1
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}

--- a/threads.cabal
+++ b/threads.cabal
@@ -50,10 +50,13 @@ source-repository head
   Type: git
   Location: git://github.com/basvandijk/threads.git
 
+custom-setup
+    setup-depends: base >= 4.4 && < 4.11, Cabal >= 1.12 && < 2.1
+
 -------------------------------------------------------------------------------
 
 library
-  build-depends: base                 >= 4.4   && < 4.10
+  build-depends: base                 >= 4.4   && < 4.11
                , stm                  >= 2.1   && < 2.5
   exposed-modules: Control.Concurrent.Thread
                  , Control.Concurrent.Thread.Group
@@ -69,9 +72,9 @@ test-suite test-threads
   ghc-options:    -Wall -threaded
 
   build-depends: threads
-               , base                 >= 4.4   && < 4.10
+               , base                 >= 4.4   && < 4.11
                , stm                  >= 2.1   && < 2.5
                , concurrent-extra     >= 0.5.1 && < 0.8
-               , HUnit                >= 1.2.2 && < 1.4
+               , HUnit                >= 1.2.2 && < 1.7
                , test-framework       >= 0.2.4 && < 0.9
                , test-framework-hunit >= 0.2.4 && < 0.4


### PR DESCRIPTION
Depends on https://github.com/basvandijk/concurrent-extra/pull/17.