### PR TITLE
GHC 9.4 compatibility

### DIFF
--- a/Control/Concurrent/Raw.hs
+++ b/Control/Concurrent/Raw.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE NoImplicitPrelude, MagicHash, UnboxedTuples #-}
+{-# LANGUAGE CPP, NoImplicitPrelude, MagicHash, UnboxedTuples #-}
 
 module Control.Concurrent.Raw ( rawForkIO, rawForkOn ) where
 
@@ -12,10 +12,18 @@ import GHC.Conc      ( ThreadId(ThreadId) )
 -- exception handler.
 {-# INLINE rawForkIO #-}
 rawForkIO :: IO () -> IO ThreadId
+#if MIN_VERSION_base(4,17,0)
+rawForkIO (IO action) = IO $ \s ->
+#else
 rawForkIO action = IO $ \s ->
+#endif
    case (fork# action s) of (# s1, tid #) -> (# s1, ThreadId tid #)
 
 {-# INLINE rawForkOn #-}
 rawForkOn :: Int -> IO () -> IO ThreadId
+#if MIN_VERSION_base(4,17,0)
+rawForkOn (I# cpu) (IO action) = IO $ \s ->
+#else
 rawForkOn (I# cpu) action = IO $ \s ->
+#endif
    case (forkOn# cpu action s) of (# s1, tid #) -> (# s1, ThreadId tid #)

--- a/test/test.hs
+++ b/test/test.hs
@@ -205,10 +205,10 @@ wrapOn_0 :: (Fork a -> IO b) -> IO b
 wrapOn_0 = wrap $ ThreadGroup.forkOn 0
 
 wrapIOWithUnmask :: (Fork a -> IO b) -> IO b
-wrapIOWithUnmask = wrap $ \tg m -> ThreadGroup.forkIOWithUnmask tg $ const m
+wrapIOWithUnmask = wrap $ \tg m -> ThreadGroup.forkIOWithUnmask tg (\_ -> m)
 
 wrapOnWithUnmask :: (Fork a -> IO b) -> IO b
-wrapOnWithUnmask = wrap $ \tg m -> ThreadGroup.forkOnWithUnmask 0 tg $ const m
+wrapOnWithUnmask = wrap $ \tg m -> ThreadGroup.forkOnWithUnmask 0 tg (\_ -> m)
 
 wrap :: (ThreadGroup -> Fork a) -> (Fork a -> IO b) -> IO b
 wrap doFork test = ThreadGroup.new >>= test . doFork


### PR DESCRIPTION
Fixes #16.

Tested with

    cabal test -w ghc-9.4.1

and

    cabal test -w ghc-9.2.4

(to verify that it still works on older versions)
