### PR TITLE
Bump timeout for flaky nrOfRunning test (fix #10)

### DIFF
--- a/test/test.hs
+++ b/test/test.hs
@@ -224,7 +224,7 @@ test_group_single_wait doFork = assert $ fmap isJustTrue $ timeout (10 * a_momen
   readIORef r
 
 test_group_nrOfRunning :: (ThreadGroup -> Fork ()) -> Assertion
-test_group_nrOfRunning doFork = assert $ fmap isJustTrue $ timeout (10 * a_moment) $ do
+test_group_nrOfRunning doFork = assert $ fmap isJustTrue $ timeout (100 * a_moment) $ do
   tg <- ThreadGroup.new
   l <- Lock.newAcquired
   replicateM_ n $ doFork tg $ Lock.acquire l


### PR DESCRIPTION
Synchronizing 100 threads can take >50ms on busy systems. This bumps the limit to a (more reasonable?) 500ms.

Fixes #10
(complain here if the 10x timeout bump is not enough :upside_down_face:)